### PR TITLE
fixing entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ RUN chmod u+x /entrypoint.sh && \
     pip3 install requests && \
     mkdir -p /data
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/bin/bash","/entrypoint.sh"]


### PR DESCRIPTION
With a current singularity pull, the entrypoint doesn't have an executable so it fails.